### PR TITLE
Issue with Alfresco on HTTPS and mixed content security issue blocked by browsers

### DIFF
--- a/alfresco-bulk-export/src/main/resources/alfresco/templates/webscripts/org/alfresco/extensions/bulkexport/export.get.html.ftl
+++ b/alfresco-bulk-export/src/main/resources/alfresco/templates/webscripts/org/alfresco/extensions/bulkexport/export.get.html.ftl
@@ -48,7 +48,7 @@
 			    visibility: visible;
 			}
    		</style>
-   		<script src="http://code.jquery.com/jquery-3.1.1.min.js" integrity="sha256-hVVnYaiADRTO2PzUGmuLJr8BLUSjGIZsDYGmIJLv2b8=" crossorigin="anonymous"></script>
+   		<script src="//code.jquery.com/jquery-3.1.1.min.js" integrity="sha256-hVVnYaiADRTO2PzUGmuLJr8BLUSjGIZsDYGmIJLv2b8=" crossorigin="anonymous"></script>
    		<script>
    			var jobsStatusMonitor;
    			var job;


### PR DESCRIPTION
Fixed mixed content issue with JQuery Reference when using HTTPS transport for Alfresco.

For example with Chrome 88: 
![image](https://user-images.githubusercontent.com/8532668/108484695-616e1100-729c-11eb-90f3-4e6e6767d24f.png)
